### PR TITLE
avoid implementation problem

### DIFF
--- a/ssr.js
+++ b/ssr.js
@@ -51,6 +51,8 @@ module.exports.ssr = async function ssr(template, script, url, options) {
     return new Promise(async (resolve, reject) => {
         try {
             const dom = await new JSDOM(template, { runScripts: "outside-only", url: host + url })
+            dom.window.rendering = true;
+            dom.window.alert = (_msg) => { };
             dom.window.scrollTo = () => { }
             dom.window.requestAnimationFrame = () => { }
             dom.window.cancelAnimationFrame = () => { }


### PR DESCRIPTION
```
alert("foo");

if ( !window.rendering ) {  // ignore rendering
   window.location.href = 'https://example.com/';
}

window.location.href = 'https://example.com/'; // Error: Not implemented: navigation (except hash changes)
```