### PR TITLE
fix: don't wait stale timeout

### DIFF
--- a/ssr.js
+++ b/ssr.js
@@ -65,12 +65,16 @@ module.exports.ssr = async function ssr(template, script, url, options) {
 
             if (eventName) {
                 dom.window.addEventListener(eventName, resolveHtml)
-                setTimeout(() => {
+                const eventTimeout = setTimeout(() => {
                     if (dom.window._document) {
                         console.log(`${url} timedout after ${timeout} ms`);
                         resolveHtml()
                     }
                 }, timeout)
+                dom.window.addEventListener(
+                    eventName,
+                    () => clearTimeout(eventTimeout)
+                )
             }
             await beforeEval(dom)
             if (meta) setMeta(dom, meta)


### PR DESCRIPTION
Clear event timeout if event already fired. This saves big amount of time in `spank` after all work is already done.

TImeout is set to 10000. Before:
```shell
➜ time spank
✔ Found matching config: Routify 2
✔ found user config: spank.config.js
✔ Inline dynamic imports
✔ Exported 7 pages in 916 ms
4.61user 0.14system 0:12.89elapsed 36%CPU (0avgtext+0avgdata 206348maxresident)k
0inputs+784outputs (0major+54695minor)pagefaults 0swaps
```
After:
```shell
➜ time spank
✔ Found matching config: Routify 2
✔ found user config: spank.config.js
✔ Inline dynamic imports
✔ Exported 7 pages in 890 ms
4.34user 0.14system 0:02.90elapsed 154%CPU (0avgtext+0avgdata 205408maxresident)k
0inputs+784outputs (0major+56510minor)pagefaults 0swaps
```
10 seconds faster.