### PR TITLE
Intercept unhandled rejections that are potentially caused by errors from jsdom

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "esbuild": "^0.7.9",
     "jsdom": "^16.4.0",
     "node-fetch": "^2.6.0",
+    "onetime": "^5.1.2",
     "utf-8-validate": "^5.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Hej @jakobrosenberg,

This is a potential fix for the issues described in https://github.com/roxiness/routify-starter/issues/97.

Basically, jsdom errors cause Node to exit (https://github.com/jsdom/jsdom/issues/2346) so this stops it from doing that. It's a little dangerous, but maybe fine if all the process is doing is handling SSR requests.

Happy to entertain any other ideas as well.