### PR TITLE
Run jsdom shutdown on the next tick to avoid errors being thrown

### DIFF
--- a/tossr.js
+++ b/tossr.js
@@ -101,7 +101,8 @@ async function tossr(template, script, url, options) {
                 afterEval(dom)
                 const html = dom.serialize()
                 resolve(html)
-                dom.window.close()
+                // Provide a tick for any queued jsdom operations to wrap up without error
+                setTimeout(() => dom.window.close(), 0)
                 if (!silent) console.log(`[tossr] ${url} - ${Date.now() - start}ms ${(inlineDynamicImports && dev) ? '(rebuilt bundle)' : ''}`)
             }
         } catch (err) { errorHandler(err, url, { options }) }


### PR DESCRIPTION
This fixed #14 for me.

However, I think this deserves a bit more thought. It can lead to `resolveHtml()` getting called twice, for example.